### PR TITLE
Find open frequency

### DIFF
--- a/Radio.py
+++ b/Radio.py
@@ -77,7 +77,6 @@ class Radio():
         if self.dbg and (firstTry == False):
             print("\tSuccessfully paired with radio.  CE: " + str(ceUsed))
 
-
     def FindOpenFrequency(self):
         # listen for two seconds to see if there is any interference on this channel
         if self.dbg:

--- a/Radio.py
+++ b/Radio.py
@@ -39,9 +39,8 @@ class Radio():
     def ConnectToRadio(self):
         # cycle through the CE pins until we are able to sync to the board
         nextCEtoTry = 0
-        ceUsed = 0
-
         connected = False
+        firstTry = False
         # silently try with current CE pin without printing anything
         if self.rfm9x != None:
             self.rfm9x.reset()
@@ -49,6 +48,7 @@ class Radio():
         try:
             self.rfm9x  = adafruit_rfm9x.RFM9x(self.spi, self.cs, self.reset, self.freq)
             connected = True
+            firstTry = True
         except Exception as e:
             if self.dbg:
                 print("Exception: " + str(e))
@@ -66,7 +66,6 @@ class Radio():
                 nextCEtoTry = 0
             try:
                 self.rfm9x  = adafruit_rfm9x.RFM9x(self.spi, self.cs, self.reset, self.freq)
-                ceUsed = nextCEtoTry
                 connected = True
             except Exception as e:
                 if self.dbg:
@@ -75,7 +74,7 @@ class Radio():
                 connected = False
 
         ceUsed = 0 if (nextCEtoTry == 1) else 1
-        if self.dbg:
+        if self.dbg and (firstTry == False):
             print("\tSuccessfully paired with radio.  CE: " + str(ceUsed))
 
 

--- a/Radio.py
+++ b/Radio.py
@@ -24,20 +24,35 @@ class Radio():
         self.rfm9x = None
         self.cs = digitalio.DigitalInOut(board.CE0)
 
+        self.ConnectToRadio()
+
+    def ConnectToRadio(self):
         # cycle through the CE pins until we are able to sync to the board
         nextCEtoTry = 0
-        while self.rfm9x == None:
+        ceUsed = 0
+
+        connected = False
+
+        while connected == False:
+            print("\tAttempting to connect to radio")
             if nextCEtoTry == 0:
                 self.cs = digitalio.DigitalInOut(board.CE0)
                 nextCEtoTry = 1
             else:
                 self.cs = digitalio.DigitalInOut(board.CE1)
                 nextCEtoTry = 0
-            self.rfm9x  = adafruit_rfm9x.RFM9x(self.spi, self.cs, self.reset, self.freq)
+            try:
+                self.rfm9x  = adafruit_rfm9x.RFM9x(self.spi, self.cs, self.reset, self.freq)
+                ceUsed = nextCEtoTry
+                connected = True
+            except Exception as e:
+                print("Exception: " + str(e))
+                print("            ^This is expected to maybe happen once or twice.")
+                connected = False
 
         ceUsed = 0 if (nextCEtoTry == 1) else 1
         if self.dbg:
-            print("Successfully paired with board.  CE: " + str(ceUsed))
+            print("\tSuccessfully paired with radio.  CE: " + str(ceUsed))
 
 
     # returns true if sync successful

--- a/Radio.py
+++ b/Radio.py
@@ -47,8 +47,11 @@ class Radio():
         if self.dbg:
             print("\tFinding an open frequency.  Starting with 902 MHZ")
 
+        # want to start at a random frequency to avoid all radios clogging the lower ones
+        # if there is more than one
+        startFreq = random.randrange(len(AllowedFrequencies))
         freqFound = False
-        for freq in AllowedFrequencies:
+        for freq in AllowedFrequencies[startFreq:] + AllowedFrequencies[:startFreq]:
             # reset the device with the new frequency
             self.rfm9x.reset()
             self.rfm9x = None

--- a/Radio.py
+++ b/Radio.py
@@ -18,6 +18,7 @@ TakeSignal              :str   = "TAKE"
 NoiseStr                :str   = "NOISE"
 SyncTimeout             :float = 0.3
 TotalSyncWaitSeconds    :float = 60.0
+
 FindFrequencyListenTime:float  = 2.0
 AllowedFrequencies:"list[float]" = [float(x) for x in range(902, 928)]
 
@@ -90,13 +91,15 @@ class Radio():
         # continuously loop through frequencies looking for sync packet
         while foundFreq == False:
             for freq in AllowedFrequencies:
+                print("Checking Frequency: " + str(freq))
                 self.rfm9x.reset()
                 self.rfm9x = None
                 self.freq = freq
+
                 while self.rfm9x == None:
                     self.rfm9x  = adafruit_rfm9x.RFM9x(self.spi, self.cs, self.reset, self.freq)
-
-                header, msg = self.ReceiveHeadedMessage(timeout=SyncTimeout*3, sendAck=False, needRightHeader=False)
+                # wait for double length of SyncTimeout to guarantee at least 1 packet will be sent
+                header, msg = self.ReceiveHeadedMessage(timeout=SyncTimeout*2, sendAck=False, needRightHeader=False)
 
                 if (header != None) and (msg == SyncStr):
                     if self.dbg:

--- a/Receiver.py
+++ b/Receiver.py
@@ -2,7 +2,7 @@ from Radio import *
 
 class Receiver:
     def __init__(self, dbg:bool):
-        self.radio = Radio(isTransmitter=False, dbg=dbg, CE="CE0")
+        self.radio = Radio(isTransmitter=False, dbg=dbg)
         self.buzzerPin = digitalio.DigitalInOut(board.D26)
         self.dbg = dbg
 
@@ -45,7 +45,7 @@ class Receiver:
 
 def main():
 
-    device = Receiver(True)
+    device = Receiver(dbg=True)
     device.Sync()
     device.EnterListenLoop()
     return

--- a/porcupine_trial.py
+++ b/porcupine_trial.py
@@ -64,7 +64,7 @@ class PorcupineDemo(Thread):
 
         self._output_path = output_path
 
-        self.radio = Radio(isTransmitter=True, dbg=True, CE="CE1")
+        self.radio = Radio(isTransmitter=True, dbg=True)
         self.radio.Sync()
 
     def run(self):


### PR DESCRIPTION
Code to find an open frequency instead of using a hardcoded one.  This should make sure we don't wind up on a frequency that is constantly having data dumped to it by some other system, as well as limiting radio->radio interference.